### PR TITLE
Error class inherits from StandardError

### DIFF
--- a/lib/pin_payment/error.rb
+++ b/lib/pin_payment/error.rb
@@ -1,5 +1,5 @@
 module PinPayment
-  class Error < Exception
+  class Error < StandardError
 
     def self.create type, description, messages = nil
       klass = case type


### PR DESCRIPTION
This will let it be caught by bare `rescue` statements, which do not rescue low level exceptions.
