### PR TITLE
Fixed remote_ip typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ charge = PinPayment::Charge.create(
   amount:      1000,
   currency:    'USD', # only AUD and USD are supported by pin.net.au
   description: 'Widgets',
-  ip_address:  request.ip
+  ip_address:  request.remote_ip
 )
 
 if charge.success?


### PR DESCRIPTION
Client IP address is obtained with `request.remote_ip`, not `request.ip`